### PR TITLE
fix: prevent max-state to be anything above "Overload"

### DIFF
--- a/src/calculate/pass_2.rs
+++ b/src/calculate/pass_2.rs
@@ -125,7 +125,7 @@ impl Item {
             let category = get_effect_category(type_dogma_effect.effectCategory);
 
             /* Find the highest state an item can be in. */
-            if category > self.max_state {
+            if category > self.max_state && category <= EffectCategory::Overload {
                 self.max_state = category;
             }
 


### PR DESCRIPTION
For example, autocannons have "Target" as higher effect. That is currently not relevant to us.