### PR TITLE
chore: switch to f64 for faster communication with Javascript

### DIFF
--- a/src/calculate/item.rs
+++ b/src/calculate/item.rs
@@ -47,8 +47,8 @@ pub struct Effect {
 
 #[derive(Serialize, Debug)]
 pub struct Attribute {
-    pub base_value: f32,
-    pub value: Option<f32>,
+    pub base_value: f64,
+    pub value: Option<f64>,
     pub effects: Vec<Effect>,
 }
 
@@ -64,7 +64,7 @@ pub struct Item {
 }
 
 impl Attribute {
-    pub fn new(value: f32) -> Attribute {
+    pub fn new(value: f64) -> Attribute {
         Attribute {
             base_value: value,
             value: None,

--- a/src/calculate/pass_1.rs
+++ b/src/calculate/pass_1.rs
@@ -11,7 +11,7 @@ const ATTRIBUTE_SKILL_LEVEL_ID: i32 = 280;
 pub struct PassOne {}
 
 impl Item {
-    pub fn set_attribute(&mut self, attribute_id: i32, value: f32) {
+    pub fn set_attribute(&mut self, attribute_id: i32, value: f64) {
         self.attributes.insert(attribute_id, Attribute::new(value));
     }
 
@@ -41,7 +41,7 @@ impl Pass for PassOne {
             let mut skill = Item::new_fake(*skill_id);
 
             skill.set_attributes(info);
-            skill.set_attribute(ATTRIBUTE_SKILL_LEVEL_ID, *skill_level as f32);
+            skill.set_attribute(ATTRIBUTE_SKILL_LEVEL_ID, *skill_level as f64);
 
             ship.skills.push(skill);
         }

--- a/src/calculate/pass_2.rs
+++ b/src/calculate/pass_2.rs
@@ -223,7 +223,7 @@ impl Pass for PassTwo {
                     for attribute_skill_id in &ATTRIBUTE_SKILLS {
                         if ship.hull.attributes.contains_key(attribute_skill_id)
                             && ship.hull.attributes[attribute_skill_id].base_value
-                                == skill_type_id as f32
+                                == skill_type_id as f64
                         {
                             ship.hull.add_effect(
                                 info,
@@ -236,7 +236,7 @@ impl Pass for PassTwo {
                         for item in &mut ship.items {
                             if item.attributes.contains_key(attribute_skill_id)
                                 && item.attributes[attribute_skill_id].base_value
-                                    == skill_type_id as f32
+                                    == skill_type_id as f64
                             {
                                 item.add_effect(
                                     info,

--- a/src/calculate/pass_3.rs
+++ b/src/calculate/pass_3.rs
@@ -5,7 +5,7 @@ use super::item::{Attribute, EffectOperator, Item, Object};
 use super::{Info, Pass, Ship};
 
 /* Penalty factor: 1 / math.exp((1 / 2.67) ** 2) */
-const PENALTY_FACTOR: f32 = 0.8691199808003974;
+const PENALTY_FACTOR: f64 = 0.8691199808003974;
 
 const OPERATOR_HAS_PENALTY: [EffectOperator; 5] = [
     EffectOperator::PreMul,
@@ -18,9 +18,9 @@ const OPERATOR_HAS_PENALTY: [EffectOperator; 5] = [
 pub struct PassThree {}
 
 struct Cache {
-    hull: BTreeMap<i32, f32>,
-    items: BTreeMap<usize, BTreeMap<i32, f32>>,
-    skills: BTreeMap<usize, BTreeMap<i32, f32>>,
+    hull: BTreeMap<i32, f64>,
+    items: BTreeMap<usize, BTreeMap<i32, f64>>,
+    skills: BTreeMap<usize, BTreeMap<i32, f64>>,
 }
 
 impl Attribute {
@@ -31,7 +31,7 @@ impl Attribute {
         cache: &mut Cache,
         item: Object,
         attribute_id: i32,
-    ) -> f32 {
+    ) -> f64 {
         if self.value.is_some() {
             return self.value.unwrap();
         }
@@ -210,7 +210,7 @@ impl Item {
         }
     }
 
-    fn store_cached_values(&mut self, info: &Info, cache: &BTreeMap<i32, f32>) {
+    fn store_cached_values(&mut self, info: &Info, cache: &BTreeMap<i32, f64>) {
         for (attribute_id, value) in cache {
             if let Some(attribute) = self.attributes.get_mut(&attribute_id) {
                 attribute.value = Some(*value);

--- a/src/calculate/pass_4.rs
+++ b/src/calculate/pass_4.rs
@@ -3,27 +3,27 @@ use super::{Info, Pass, Ship};
 
 pub struct PassFour {}
 
-fn add_attribute(ship: &mut Ship, attribute_id: i32, base_value: f32, value: f32) {
+fn add_attribute(ship: &mut Ship, attribute_id: i32, base_value: f64, value: f64) {
     let mut attribute = Attribute::new(base_value);
     attribute.value = Some(value);
     ship.hull.attributes.insert(attribute_id, attribute);
 }
 
-fn calculate_align_time(ship: &mut Ship) -> (f32, f32) {
+fn calculate_align_time(ship: &mut Ship) -> (f64, f64) {
     /* Align-time is based on agility (70) and mass (4). */
 
     let base_agility = ship.hull.attributes.get(&70).unwrap().base_value;
     let base_mass = ship.hull.attributes.get(&4).unwrap().base_value;
-    let base_align_time = -(0.25 as f32).ln() * base_agility * base_mass / 1000000.0;
+    let base_align_time = -(0.25 as f64).ln() * base_agility * base_mass / 1000000.0;
 
     let agility = ship.hull.attributes.get(&70).unwrap().value.unwrap();
     let mass = ship.hull.attributes.get(&4).unwrap().value.unwrap();
-    let align_time = -(0.25 as f32).ln() * agility * mass / 1000000.0;
+    let align_time = -(0.25 as f64).ln() * agility * mass / 1000000.0;
 
     (base_align_time, align_time)
 }
 
-fn add_scan_strength(ship: &mut Ship) -> (f32, f32) {
+fn add_scan_strength(ship: &mut Ship) -> (f64, f64) {
     /* Scan Strength can be one of 4 values. */
 
     let mut base_scan_strength = 0.0;
@@ -44,7 +44,7 @@ fn add_scan_strength(ship: &mut Ship) -> (f32, f32) {
     (base_scan_strength, scan_strength)
 }
 
-fn add_cpu_used(ship: &mut Ship) -> (f32, f32) {
+fn add_cpu_used(ship: &mut Ship) -> (f64, f64) {
     /* How much CPU is being used, which is adding up cpuOuput (50) from all items. */
 
     let mut cpu_used = 0.0;
@@ -57,7 +57,7 @@ fn add_cpu_used(ship: &mut Ship) -> (f32, f32) {
     (0.0, cpu_used)
 }
 
-fn add_pg_used(ship: &mut Ship) -> (f32, f32) {
+fn add_pg_used(ship: &mut Ship) -> (f64, f64) {
     /* How much PG is being used, which is adding up powerOutput (30) from all items. */
 
     let mut pg_used = 0.0;
@@ -70,7 +70,7 @@ fn add_pg_used(ship: &mut Ship) -> (f32, f32) {
     (0.0, pg_used)
 }
 
-fn add_cpu_unused(ship: &mut Ship) -> (f32, f32) {
+fn add_cpu_unused(ship: &mut Ship) -> (f64, f64) {
     /* How much CPU is left, which is the total CPU minus the usage. */
 
     let cpu_used = ship.hull.attributes.get(&-3).unwrap().value.unwrap();
@@ -80,7 +80,7 @@ fn add_cpu_unused(ship: &mut Ship) -> (f32, f32) {
     (0.0, cpu_unused)
 }
 
-fn add_pg_unused(ship: &mut Ship) -> (f32, f32) {
+fn add_pg_unused(ship: &mut Ship) -> (f64, f64) {
     /* How much PG is left, which is the total PG minus the usage. */
 
     let pg_used = ship.hull.attributes.get(&-4).unwrap().value.unwrap();

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -6,17 +6,17 @@ use serde_repr::*;
 pub struct TypeId {
     pub groupID: i32,
     pub categoryID: i32,
-    pub capacity: Option<f32>,
-    pub mass: Option<f32>,
-    pub radius: Option<f32>,
-    pub volume: Option<f32>,
+    pub capacity: Option<f64>,
+    pub mass: Option<f64>,
+    pub radius: Option<f64>,
+    pub volume: Option<f64>,
 }
 
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
 pub struct TypeDogmaAttribute {
     pub attributeID: i32,
-    pub value: f32,
+    pub value: f64,
 }
 
 #[allow(non_snake_case)]
@@ -36,7 +36,7 @@ pub struct TypeDogma {
 #[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
 pub struct DogmaAttribute {
-    pub defaultValue: f32,
+    pub defaultValue: f64,
     pub highIsGood: bool,
     pub stackable: bool,
 }


### PR DESCRIPTION
Javascript is natively already f64, so no need for conversion.