### PR TITLE
fix: stacking penalties don't depend on high-is-good property

### DIFF
--- a/src/calculate/pass_3.rs
+++ b/src/calculate/pass_3.rs
@@ -138,8 +138,6 @@ impl Attribute {
                 | EffectOperator::PostMul
                 | EffectOperator::PostDiv
                 | EffectOperator::PostPercent => {
-                    let dogma_attribute = info.get_dogma_attribute(attribute_id);
-
                     /* values.0 are non-stacking. */
                     for value in values.0 {
                         current_value *= 1.0 + value;
@@ -148,14 +146,9 @@ impl Attribute {
                     let highest_sort = |x: &f64, y: &f64| x.abs().partial_cmp(&y.abs()).unwrap();
                     let lowest_sort = |x: &f64, y: &f64| y.abs().partial_cmp(&x.abs()).unwrap();
 
-                    /* Sort values.1 (positive values) and values.2 (negative values) based on high-is-good. */
-                    if dogma_attribute.highIsGood {
-                        values.1.sort_by(highest_sort);
-                        values.2.sort_by(lowest_sort);
-                    } else {
-                        values.1.sort_by(lowest_sort);
-                        values.2.sort_by(highest_sort);
-                    }
+                    /* For positive values, the highest number goes first. For negative values, the lowest number. */
+                    values.1.sort_by(highest_sort);
+                    values.2.sort_by(lowest_sort);
 
                     /* Apply positive stacking penalty. */
                     for (index, value) in values.1.iter().enumerate() {


### PR DESCRIPTION
Instead, in the dataset there was a wrong high-is-good for an attribute, which made it appear for some attributes it depended on it.