### PR TITLE
chore!: make input/output of calculate() easier to understand

### DIFF
--- a/src/calculate.rs
+++ b/src/calculate.rs
@@ -54,9 +54,9 @@ trait Pass {
     fn pass(info: &Info, ship: &mut Ship);
 }
 
-pub fn calculate(esi_fit: &super::data_types::EsiFit, skills: &BTreeMap<i32, i32>) -> Ship {
-    let info = Info::new(esi_fit, skills);
-    let mut ship = Ship::new(info.esi_fit.ship_type_id);
+pub fn calculate(fit: &super::data_types::EsfFit, skills: &BTreeMap<i32, i32>) -> Ship {
+    let info = Info::new(fit, skills);
+    let mut ship = Ship::new(info.fit.ship_type_id);
 
     pass_1::PassOne::pass(&info, &mut ship);
     pass_2::PassTwo::pass(&info, &mut ship);

--- a/src/calculate/info.rs
+++ b/src/calculate/info.rs
@@ -23,13 +23,13 @@ extern "C" {
 }
 
 pub struct Info<'a> {
-    pub esi_fit: &'a data_types::EsiFit,
+    pub fit: &'a data_types::EsfFit,
     pub skills: &'a BTreeMap<i32, i32>,
 }
 
 impl Info<'_> {
-    pub fn new<'a>(esi_fit: &'a data_types::EsiFit, skills: &'a BTreeMap<i32, i32>) -> Info<'a> {
-        Info { esi_fit, skills }
+    pub fn new<'a>(fit: &'a data_types::EsfFit, skills: &'a BTreeMap<i32, i32>) -> Info<'a> {
+        Info { fit, skills }
     }
 
     pub fn get_dogma_attributes(&self, type_id: i32) -> Vec<data_types::TypeDogmaAttribute> {

--- a/src/calculate/pass_2.rs
+++ b/src/calculate/pass_2.rs
@@ -176,11 +176,6 @@ impl Item {
             }
         }
 
-        /* Drones can always be active, but there is no effect that indicates this. */
-        if self.flag == 87 {
-            self.max_state = EffectCategory::Active;
-        }
-
         /* Any module that has a capacitorNeed (6), can be activated. */
         if self.attributes.contains_key(&6) && self.max_state < EffectCategory::Active {
             self.max_state = EffectCategory::Active;
@@ -212,7 +207,7 @@ impl Pass for PassTwo {
         /* Depending on the modifier, move the effects to the correct attribute. */
         for effect in effects {
             let source_type_id = match effect.source {
-                Object::Ship => info.esi_fit.ship_type_id,
+                Object::Ship => info.fit.ship_type_id,
                 Object::Item(index) => ship.items[index].type_id,
                 Object::Charge(index) => ship.items[index].charge.as_ref().unwrap().type_id,
                 Object::Skill(index) => ship.skills[index].type_id,

--- a/src/calculate/pass_4/capacitor.rs
+++ b/src/calculate/pass_4/capacitor.rs
@@ -1,4 +1,3 @@
-use super::super::item::EffectCategory;
 use super::super::Ship;
 use super::AttributeId;
 
@@ -41,7 +40,7 @@ pub fn attribute_capacitor_peak_usage(ship: &mut Ship) {
     let mut base_peak_usage = 0.0;
     let mut peak_usage = 0.0;
     for item in &ship.items {
-        if item.state == EffectCategory::Passive || item.state == EffectCategory::Online {
+        if !item.slot.is_module() || !item.state.is_active() {
             continue;
         }
 
@@ -183,7 +182,7 @@ pub fn attribute_capacitor_depletes_in(ship: &mut Ship) {
         /* Find all modules consuming capacitor. */
         let mut modules = Vec::new();
         for item in &ship.items {
-            if item.state == EffectCategory::Passive || item.state == EffectCategory::Online {
+            if !item.slot.is_module() || !item.state.is_active() {
                 continue;
             }
 

--- a/src/calculate/pass_4/cpu_power.rs
+++ b/src/calculate/pass_4/cpu_power.rs
@@ -9,7 +9,7 @@ pub fn attribute_cpu_used(ship: &mut Ship) {
 
     let mut cpu_used = 0.0;
     for item in &ship.items {
-        if item.state == EffectCategory::Passive {
+        if !item.slot.is_module() || item.state == EffectCategory::Passive {
             continue;
         }
 
@@ -28,7 +28,7 @@ pub fn attribute_power_used(ship: &mut Ship) {
 
     let mut power_used = 0.0;
     for item in &ship.items {
-        if item.state == EffectCategory::Passive {
+        if !item.slot.is_module() || item.state == EffectCategory::Passive {
             continue;
         }
 

--- a/src/calculate/pass_4/damage.rs
+++ b/src/calculate/pass_4/damage.rs
@@ -1,4 +1,4 @@
-use super::super::item::{EffectCategory, Item};
+use super::super::item::Item;
 use super::super::Ship;
 use super::AttributeId;
 
@@ -86,7 +86,7 @@ pub fn attribute_damage_alpha_hp(ship: &mut Ship) {
     let mut total_alpha_hp = 0.0;
 
     for item in &mut ship.items {
-        if item.state == EffectCategory::Passive || item.state == EffectCategory::Online {
+        if !item.slot.is_module() || !item.state.is_active() {
             continue;
         }
 
@@ -125,7 +125,7 @@ pub fn attribute_damage_without_reload(ship: &mut Ship) {
     let mut total_damage = 0.0;
 
     for item in &mut ship.items {
-        if item.state == EffectCategory::Passive || item.state == EffectCategory::Online {
+        if !item.slot.is_module() || !item.state.is_active() {
             continue;
         }
 
@@ -170,7 +170,7 @@ pub fn attribute_damage_with_reload(ship: &mut Ship) {
     let mut total_damage = 0.0;
 
     for item in &mut ship.items {
-        if item.state == EffectCategory::Passive || item.state == EffectCategory::Online {
+        if !item.slot.is_module() || !item.state.is_active() {
             continue;
         }
 

--- a/src/calculate/pass_4/drone.rs
+++ b/src/calculate/pass_4/drone.rs
@@ -1,4 +1,4 @@
-use super::super::item::EffectCategory;
+use super::super::item::{EffectCategory, SlotType};
 use super::super::Ship;
 use super::AttributeId;
 
@@ -7,9 +7,11 @@ pub fn attribute_drone_active(ship: &mut Ship) {
 
     let mut active = 0;
     for item in &ship.items {
-        if item.flag == 87 && item.state == EffectCategory::Active {
-            active += 1;
+        if item.slot.r#type != SlotType::DroneBay || item.state != EffectCategory::Active {
+            continue;
         }
+
+        active += 1;
     }
 
     ship.hull
@@ -23,14 +25,16 @@ pub fn attribute_drone_capacity_used(ship: &mut Ship) {
 
     let mut capacity_used = 0.0;
     for item in &ship.items {
-        if item.flag == 87 {
-            capacity_used += item
-                .attributes
-                .get(&attr_drone_capacity)
-                .unwrap()
-                .value
-                .unwrap();
+        if item.slot.r#type != SlotType::DroneBay {
+            continue;
         }
+
+        capacity_used += item
+            .attributes
+            .get(&attr_drone_capacity)
+            .unwrap()
+            .value
+            .unwrap();
     }
 
     ship.hull
@@ -44,14 +48,16 @@ pub fn attribute_drone_bandwidth_used(ship: &mut Ship) {
 
     let mut bandwidth_used_total = 0.0;
     for item in &ship.items {
-        if item.flag == 87 && item.state == EffectCategory::Active {
-            bandwidth_used_total += item
-                .attributes
-                .get(&attr_drone_bandwidth)
-                .unwrap()
-                .value
-                .unwrap();
+        if item.slot.r#type != SlotType::DroneBay || item.state != EffectCategory::Active {
+            continue;
         }
+
+        bandwidth_used_total += item
+            .attributes
+            .get(&attr_drone_bandwidth)
+            .unwrap()
+            .value
+            .unwrap();
     }
 
     ship.hull.add_attribute(
@@ -73,21 +79,23 @@ pub fn attribute_drone_damage(ship: &mut Ship) {
     let attr_damage_without_reload_dps = AttributeId::damageWithoutReloadDps as i32;
 
     for item in &mut ship.items {
-        if item.flag == 87
-            && item.state == EffectCategory::Active
-            && item.attributes.contains_key(&attr_damage_alpha_hp)
-        {
-            let damage_alpha_hp = item.attributes.get(&attr_damage_alpha_hp).unwrap();
-            total_base_alpha_hp += damage_alpha_hp.base_value;
-            total_alpha_hp += damage_alpha_hp.value.unwrap();
-
-            let damage_without_reload_dps = item
-                .attributes
-                .get(&attr_damage_without_reload_dps)
-                .unwrap();
-            total_base_alpha_hp_without_reload += damage_without_reload_dps.base_value;
-            total_alpha_hp_without_reload += damage_without_reload_dps.value.unwrap();
+        if item.slot.r#type != SlotType::DroneBay || item.state != EffectCategory::Active {
+            continue;
         }
+        if !item.attributes.contains_key(&attr_damage_alpha_hp) {
+            continue;
+        }
+
+        let damage_alpha_hp = item.attributes.get(&attr_damage_alpha_hp).unwrap();
+        total_base_alpha_hp += damage_alpha_hp.base_value;
+        total_alpha_hp += damage_alpha_hp.value.unwrap();
+
+        let damage_without_reload_dps = item
+            .attributes
+            .get(&attr_damage_without_reload_dps)
+            .unwrap();
+        total_base_alpha_hp_without_reload += damage_without_reload_dps.base_value;
+        total_alpha_hp_without_reload += damage_without_reload_dps.value.unwrap();
     }
 
     ship.hull.add_attribute(

--- a/src/calculate/pass_4/recharge.rs
+++ b/src/calculate/pass_4/recharge.rs
@@ -1,4 +1,3 @@
-use super::super::item::EffectCategory;
 use super::super::Ship;
 use super::AttributeId;
 
@@ -56,32 +55,42 @@ pub fn attribute_shield_recharge(ship: &mut Ship) {
 
     let mut base_shield_recharge = 0.0;
     for item in &ship.items {
-        if item.attributes.contains_key(&attr_duration)
-            && item.attributes.contains_key(&attr_shield_bonus)
-            && item.state >= EffectCategory::Active
-        {
-            let duration = item.attributes.get(&attr_duration).unwrap().base_value / 1000.0;
-            base_shield_recharge +=
-                item.attributes.get(&attr_shield_bonus).unwrap().base_value / duration;
+        if !item.slot.is_module() || !item.state.is_active() {
+            continue;
         }
+
+        if !item.attributes.contains_key(&attr_duration)
+            || !item.attributes.contains_key(&attr_shield_bonus)
+        {
+            continue;
+        }
+
+        let duration = item.attributes.get(&attr_duration).unwrap().base_value / 1000.0;
+        base_shield_recharge +=
+            item.attributes.get(&attr_shield_bonus).unwrap().base_value / duration;
     }
     let base_shield_ehp_multiplier = attr_shield_ehp_multiplier.base_value;
 
     let mut shield_recharge = 0.0;
     for item in &ship.items {
-        if item.attributes.contains_key(&attr_duration)
-            && item.attributes.contains_key(&attr_shield_bonus)
-            && item.state >= EffectCategory::Active
-        {
-            let duration = item.attributes.get(&attr_duration).unwrap().value.unwrap() / 1000.0;
-            shield_recharge += item
-                .attributes
-                .get(&attr_shield_bonus)
-                .unwrap()
-                .value
-                .unwrap()
-                / duration;
+        if !item.slot.is_module() || !item.state.is_active() {
+            continue;
         }
+
+        if !item.attributes.contains_key(&attr_duration)
+            || !item.attributes.contains_key(&attr_shield_bonus)
+        {
+            continue;
+        }
+
+        let duration = item.attributes.get(&attr_duration).unwrap().value.unwrap() / 1000.0;
+        shield_recharge += item
+            .attributes
+            .get(&attr_shield_bonus)
+            .unwrap()
+            .value
+            .unwrap()
+            / duration;
     }
     let shield_ehp_multiplier = attr_shield_ehp_multiplier.value.unwrap();
 
@@ -110,32 +119,42 @@ pub fn attribute_armor_recharge(ship: &mut Ship) {
 
     let mut base_armor_recharge = 0.0;
     for item in &ship.items {
-        if item.attributes.contains_key(&attr_duration)
-            && item.attributes.contains_key(&attr_armor_bonus)
-            && item.state >= EffectCategory::Active
-        {
-            let duration = item.attributes.get(&attr_duration).unwrap().base_value / 1000.0;
-            base_armor_recharge +=
-                item.attributes.get(&attr_armor_bonus).unwrap().base_value / duration;
+        if !item.slot.is_module() || !item.state.is_active() {
+            continue;
         }
+
+        if !item.attributes.contains_key(&attr_duration)
+            || !item.attributes.contains_key(&attr_armor_bonus)
+        {
+            continue;
+        }
+
+        let duration = item.attributes.get(&attr_duration).unwrap().base_value / 1000.0;
+        base_armor_recharge +=
+            item.attributes.get(&attr_armor_bonus).unwrap().base_value / duration;
     }
     let base_armor_ehp_multiplier = attr_armor_ehp_multiplier.base_value;
 
     let mut armor_recharge = 0.0;
     for item in &ship.items {
-        if item.attributes.contains_key(&attr_duration)
-            && item.attributes.contains_key(&attr_armor_bonus)
-            && item.state >= EffectCategory::Active
-        {
-            let duration = item.attributes.get(&attr_duration).unwrap().value.unwrap() / 1000.0;
-            armor_recharge += item
-                .attributes
-                .get(&attr_armor_bonus)
-                .unwrap()
-                .value
-                .unwrap()
-                / duration;
+        if !item.slot.is_module() || !item.state.is_active() {
+            continue;
         }
+
+        if !item.attributes.contains_key(&attr_duration)
+            || !item.attributes.contains_key(&attr_armor_bonus)
+        {
+            continue;
+        }
+
+        let duration = item.attributes.get(&attr_duration).unwrap().value.unwrap() / 1000.0;
+        armor_recharge += item
+            .attributes
+            .get(&attr_armor_bonus)
+            .unwrap()
+            .value
+            .unwrap()
+            / duration;
     }
     let armor_ehp_multiplier = attr_armor_ehp_multiplier.value.unwrap();
 
@@ -164,32 +183,41 @@ pub fn attribute_hull_recharge(ship: &mut Ship) {
 
     let mut base_hull_recharge = 0.0;
     for item in &ship.items {
-        if item.attributes.contains_key(&attr_duration)
-            && item.attributes.contains_key(&attr_hull_bonus)
-            && item.state >= EffectCategory::Active
-        {
-            let duration = item.attributes.get(&attr_duration).unwrap().base_value / 1000.0;
-            base_hull_recharge +=
-                item.attributes.get(&attr_hull_bonus).unwrap().base_value / duration;
+        if !item.slot.is_module() || !item.state.is_active() {
+            continue;
         }
+
+        if !item.attributes.contains_key(&attr_duration)
+            || !item.attributes.contains_key(&attr_hull_bonus)
+        {
+            continue;
+        }
+
+        let duration = item.attributes.get(&attr_duration).unwrap().base_value / 1000.0;
+        base_hull_recharge += item.attributes.get(&attr_hull_bonus).unwrap().base_value / duration;
     }
     let base_hull_ehp_multiplier = attr_hull_ehp_multiplier.base_value;
 
     let mut hull_recharge = 0.0;
     for item in &ship.items {
-        if item.attributes.contains_key(&attr_duration)
-            && item.attributes.contains_key(&attr_hull_bonus)
-            && item.state >= EffectCategory::Active
-        {
-            let duration = item.attributes.get(&attr_duration).unwrap().value.unwrap() / 1000.0;
-            hull_recharge += item
-                .attributes
-                .get(&attr_hull_bonus)
-                .unwrap()
-                .value
-                .unwrap()
-                / duration;
+        if !item.slot.is_module() || !item.state.is_active() {
+            continue;
         }
+
+        if !item.attributes.contains_key(&attr_duration)
+            || !item.attributes.contains_key(&attr_hull_bonus)
+        {
+            continue;
+        }
+
+        let duration = item.attributes.get(&attr_duration).unwrap().value.unwrap() / 1000.0;
+        hull_recharge += item
+            .attributes
+            .get(&attr_hull_bonus)
+            .unwrap()
+            .value
+            .unwrap()
+            / duration;
     }
     let hull_ehp_multiplier = attr_hull_ehp_multiplier.value.unwrap();
 

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -98,34 +98,51 @@ pub struct DogmaEffect {
     pub modifierInfo: Vec<DogmaEffectModifierInfo>,
 }
 
-#[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
-pub enum EsiState {
+pub enum EsfState {
     Passive,
     Online,
     Active,
     Overload,
 }
 
-#[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
-pub struct EsiCharge {
+pub enum EsfSlotType {
+    High,
+    Medium,
+    Low,
+    Rig,
+    SubSystem,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct EsfCharge {
     pub type_id: i32,
 }
 
-#[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
-pub struct EsiItem {
-    pub type_id: i32,
-    pub quantity: i32,
-    pub flag: i32,
-    pub charge: Option<EsiCharge>,
-    pub state: Option<EsiState>,
+pub struct EsfSlot {
+    pub r#type: EsfSlotType,
+    pub index: i32,
 }
 
-#[allow(non_snake_case)]
 #[derive(Deserialize, Debug)]
-pub struct EsiFit {
+pub struct EsfModule {
+    pub type_id: i32,
+    pub slot: EsfSlot,
+    pub state: EsfState,
+    pub charge: Option<EsfCharge>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct EsfDrone {
+    pub type_id: i32,
+    pub state: EsfState,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct EsfFit {
     pub ship_type_id: i32,
-    pub items: Vec<EsiItem>,
+    pub modules: Vec<EsfModule>,
+    pub drones: Vec<EsfDrone>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,14 @@ pub fn init() {
 }
 
 #[wasm_bindgen]
-pub fn calculate(js_ship_layout: JsValue, js_skills: JsValue) -> JsValue {
-    let esi_fit: data_types::EsiFit = serde_wasm_bindgen::from_value(js_ship_layout).unwrap();
+pub fn calculate(js_esf_fit: JsValue, js_skills: JsValue) -> JsValue {
+    let fit: data_types::EsfFit = serde_wasm_bindgen::from_value(js_esf_fit).unwrap();
     let skills: BTreeMap<String, i32> = serde_wasm_bindgen::from_value(js_skills).unwrap();
     let skills = skills
         .into_iter()
         .map(|(k, v)| (k.parse::<i32>().unwrap(), v))
         .collect();
 
-    let statistics = calculate::calculate(&esi_fit, &skills);
+    let statistics = calculate::calculate(&fit, &skills);
     serde_wasm_bindgen::to_value(&statistics).unwrap()
 }


### PR DESCRIPTION
No longer follow ESI Fitting JSON, as it is lacking in many places. Instead, use a custom format, that is easier to explain. For example, "flag" is now a "slot", which contains the "type" ("Low", "Medium", ..) and "index" (1, 2, 3, ..).

There is also now `modules` and `drones`, instead of a single `items` list. Please never send `cargo` in either of the two, as it will be processed ;)

In result, this library no longer has any knowledge of the ESI "flags".