### PR TITLE
chore: rename PostAssignment to PostAssign

### DIFF
--- a/src/calculate/item.rs
+++ b/src/calculate/item.rs
@@ -24,7 +24,7 @@ pub enum EffectOperator {
     PostMul,
     PostDiv,
     PostPercent,
-    PostAssignment,
+    PostAssign,
 }
 
 #[derive(Serialize, Debug, Copy, Clone)]

--- a/src/calculate/pass_2.rs
+++ b/src/calculate/pass_2.rs
@@ -93,7 +93,7 @@ fn get_effect_operator(operation: i32) -> Option<EffectOperator> {
         4 => Some(EffectOperator::PostMul),
         5 => Some(EffectOperator::PostDiv),
         6 => Some(EffectOperator::PostPercent),
-        7 => Some(EffectOperator::PostAssignment),
+        7 => Some(EffectOperator::PostAssign),
         /* We ignore operator 9 (calculates Skill Level based on Skill Points; irrelevant for fits). */
         9 => None,
         _ => panic!("Unknown effect operation: {}", operation),

--- a/src/calculate/pass_3.rs
+++ b/src/calculate/pass_3.rs
@@ -104,7 +104,7 @@ impl Attribute {
                     EffectOperator::PostMul => source_value - 1.0,
                     EffectOperator::PostDiv => 1.0 / source_value - 1.0,
                     EffectOperator::PostPercent => source_value / 100.0,
-                    EffectOperator::PostAssignment => source_value,
+                    EffectOperator::PostAssign => source_value,
                 };
 
                 /* Check whether stacking penalty counts; negative and positive values have their own penalty. */
@@ -125,7 +125,7 @@ impl Attribute {
 
             /* Apply the operator on the values. */
             match operator {
-                EffectOperator::PreAssign | EffectOperator::PostAssignment => {
+                EffectOperator::PreAssign | EffectOperator::PostAssign => {
                     let dogma_attribute = info.get_dogma_attribute(attribute_id);
 
                     current_value = if dogma_attribute.highIsGood {


### PR DESCRIPTION
This way it matches up with PreAssign and other names