### PR TITLE
fix: short option for 'state' and 'skills_filename' is identical

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ struct Args {
     #[clap(short, long)]
     eft_filename: Option<PathBuf>,
 
-    #[clap(short, long)]
+    #[clap(short = 'f', long)]
     skills_filename: Option<PathBuf>,
 
     #[clap(short, long, default_value = "node_modules/@eveshipfit/data/dist/sde")]


### PR DESCRIPTION
Short option names must be unique for each argument, but '-s' is in use by both 'state' and 'skills_filename'